### PR TITLE
Refactor to control objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ src/mixxx.rc.include
 src/mixxx.res
 src/test/**/*.actual
 res/qrc_mixxx.cc
+/.vs

--- a/pre-commit.patch
+++ b/pre-commit.patch
@@ -1,0 +1,141 @@
+diff --git a/src/preferences/dialog/dlgprefdeck.h b/src/preferences/dialog/dlgprefdeck.h
+index 38b7d61..e27f897 100644
+--- a/src/preferences/dialog/dlgprefdeck.h
++++ b/src/preferences/dialog/dlgprefdeck.h
+@@ -23,21 +23,21 @@ constexpr bool kDefaultCloneDeckOnLoad = true;
+ }
+ 
+ namespace TrackTime {
+-    enum class DisplayMode {
+-        ELAPSED,
+-        REMAINING,
+-        ELAPSED_AND_REMAINING,
+-        BEATS_UNTIL_NEXT_CUE_AND_REMAINING,
+-    };
+-
+-    enum class DisplayFormat {
+-        TRADITIONAL,
+-        TRADITIONAL_COARSE,
+-        SECONDS,
+-        SECONDS_LONG,
+-        KILO_SECONDS,
+-        HECTO_SECONDS,
+-    };
++enum class DisplayMode {
++    ELAPSED,
++    REMAINING,
++    ELAPSED_AND_REMAINING,
++    BEATS_UNTIL_NEXT_CUE_AND_REMAINING,
++};
++
++enum class DisplayFormat {
++    TRADITIONAL,
++    TRADITIONAL_COARSE,
++    SECONDS,
++    SECONDS_LONG,
++    KILO_SECONDS,
++    HECTO_SECONDS,
++};
+ }
+ 
+ enum class KeylockMode {
+diff --git a/src/widget/wnumberpos.cpp b/src/widget/wnumberpos.cpp
+index 43b6722..d6d6f28 100644
+--- a/src/widget/wnumberpos.cpp
++++ b/src/widget/wnumberpos.cpp
+@@ -2,18 +2,17 @@
+ 
+ #include "control/controlobject.h"
+ #include "control/controlproxy.h"
++#include "engine/enginebuffer.h"
++#include "mixer/deck.h"
+ #include "moc_wnumberpos.cpp"
++#include "track/track.h"
+ #include "util/duration.h"
+ #include "util/math.h"
+-#include "track/track.h"
+-#include "mixer/deck.h"
+-#include "engine/enginebuffer.h"
+ 
+ WNumberPos::WNumberPos(const QString& group, QWidget* parent, Deck* deck)
+         : WNumber(parent),
+           m_displayFormat(TrackTime::DisplayFormat::TRADITIONAL),
+           m_dOldTimeElapsed(0.0) {
+-
+     m_pDeck = deck;
+ 
+     m_pTimeElapsed = new ControlProxy(group, "time_elapsed", this, ControlFlag::NoAssertIfMissing);
+@@ -102,16 +101,14 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
+                     % QLatin1String("  -") % timeFormat(dTimeRemaining, precision));
+         }
+     } else if (m_displayMode == TrackTime::DisplayMode::BEATS_UNTIL_NEXT_CUE_AND_REMAINING) {
+-
+         if (m_pDeck) {
+             TrackPointer m_pTrack = m_pDeck->getLoadedTrack();
+             if (m_pTrack) {
+-
+                 mixxx::audio::FramePos currentFramePos = m_pDeck->getEngineDeck()->getEngineBuffer()->getExactPlayPos();
+                 QList<CuePointer> trackCues = m_pTrack->getCuePoints();
+-                QList<mixxx::audio::FramePos> cuesFromCurrentPosition =  QList<mixxx::audio::FramePos>();
++                QList<mixxx::audio::FramePos> cuesFromCurrentPosition = QList<mixxx::audio::FramePos>();
+ 
+-                //Iterate through current Track cues and create a list with the FramePos of the ones 
++                //Iterate through current Track cues and create a list with the FramePos of the ones
+                 // that are after the current play position. We add them ordered in the new list
+                 for (int i = 0; i < trackCues.count(); ++i) {
+                     CuePointer cue = trackCues[i];
+@@ -119,8 +116,7 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
+                     if (cueFramePos.isValid() && cueFramePos >= currentFramePos) {
+                         if (cuesFromCurrentPosition.isEmpty()) {
+                             cuesFromCurrentPosition.append(cueFramePos);
+-                        }
+-                        else if (cuesFromCurrentPosition.first() < cueFramePos) {
++                        } else if (cuesFromCurrentPosition.first() < cueFramePos) {
+                             cuesFromCurrentPosition.append(cueFramePos);
+                         } else {
+                             cuesFromCurrentPosition.insert(0, cueFramePos);
+@@ -133,19 +129,22 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
+                 //ToDo (Maldini) - Get beat counters for every cue point to help with multi drop mixes
+                 std::string cuesText = "";
+                 if (!cuesFromCurrentPosition.isEmpty()) {
+-                    mixxx::audio::FramePos closestCueFramePos = cuesFromCurrentPosition.first();
+-                    m_pTrack->getBeats()->numBeatsInRange(currentFramePos, closestCueFramePos);
++                    mixxx::audio::FramePos closestCueFramePos =
++                            cuesFromCurrentPosition.first();
++                    m_pTrack->getBeats()->numBeatsInRange(
++                            currentFramePos, closestCueFramePos);
+                     cuesText = std::to_string(m_pTrack->getBeats()->numBeatsInRange(currentFramePos, closestCueFramePos));
+-                
++
+                 } else {
+                     setText(QString::fromStdString("No cues left | -") + timeFormat(dTimeRemaining, precision));
+                 }
+ 
+                 setText(QString::fromStdString(cuesText + " beats | " + "-") + timeFormat(dTimeRemaining, precision));
+- 
++
+             } else {
+                 //Fallback to remaining time display
+-                setText(QLatin1String("-") % timeFormat(dTimeRemaining, precision));
++                setText(QLatin1String("-") %
++                        timeFormat(dTimeRemaining, precision));
+             }
+         } else {
+             //Fallback to remaining time display
+diff --git a/src/widget/wnumberpos.h b/src/widget/wnumberpos.h
+index 999dc24..44f0274 100644
+--- a/src/widget/wnumberpos.h
++++ b/src/widget/wnumberpos.h
+@@ -2,10 +2,9 @@
+ 
+ #include <QMouseEvent>
+ 
+-#include "wnumber.h"
+-#include "preferences/dialog/dlgprefdeck.h"
+ #include "mixer/basetrackplayer.h"
+-
++#include "preferences/dialog/dlgprefdeck.h"
++#include "wnumber.h"
+ 
+ class ControlProxy;
+ 

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -18,6 +18,7 @@ constexpr double kSignificiantRateThreshold =
 ClockControl::ClockControl(const QString& group, UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
           m_pCOBeatActive(std::make_unique<ControlObject>(ConfigKey(group, "beat_active"))),
+          m_pBeatCountNextCue(std::make_unique<ControlObject>(ConfigKey(group, "beat_count_next_cue"))),
           m_pLoopEnabled(std::make_unique<ControlProxy>(group, "loop_enabled", this)),
           m_pLoopStartPosition(std::make_unique<ControlProxy>(group, "loop_start_position", this)),
           m_pLoopEndPosition(std::make_unique<ControlProxy>(group, "loop_end_position", this)),
@@ -29,6 +30,8 @@ ClockControl::ClockControl(const QString& group, UserSettingsPointer pConfig)
           m_internalState(StateMachine::outsideIndicationArea) {
     m_pCOBeatActive->setReadOnly();
     m_pCOBeatActive->forceSet(0.0);
+    m_pBeatCountNextCue->forceSet(0.0);
+
 }
 
 ClockControl::~ClockControl() = default;
@@ -38,6 +41,7 @@ void ClockControl::trackLoaded(TrackPointer pNewTrack) {
     mixxx::BeatsPointer pBeats;
     if (pNewTrack) {
         pBeats = pNewTrack->getBeats();
+        m_pTrackCues = pNewTrack->getCuePoints();
     }
     trackBeatsUpdated(pBeats);
 }
@@ -85,6 +89,7 @@ void ClockControl::updateIndicators(const double dRate,
                     &m_nextBeatPosition,
                     false); // Precise compare without tolerance needed
         }
+        updateBeatCounter(pBeats, currentPosition);
     } else {
         m_prevBeatPosition = mixxx::audio::kInvalidFramePos;
         m_nextBeatPosition = mixxx::audio::kInvalidFramePos;
@@ -203,4 +208,47 @@ void ClockControl::updateIndicators(const double dRate,
         m_lastPlayDirectionWasForwards = false;
     }
     m_lastEvaluatedPosition = currentPosition;
+}
+
+void ClockControl::updateBeatCounter(mixxx::BeatsPointer pBeats, 
+    mixxx::audio::FramePos currentFramePos) {
+
+    QList<mixxx::audio::FramePos> cuesFromCurrentPosition =
+            QList<mixxx::audio::FramePos>();
+
+    //Iterate through current Track cues and create a list with the FramePos of the ones
+    // that are after the current play position. We add them ordered in the new list
+    for (int i = 0; i < m_pTrackCues.count(); ++i) {
+        CuePointer cue = m_pTrackCues[i];
+        mixxx::audio::FramePos cueFramePos = cue->getPosition();
+        if (cueFramePos.isValid()) {
+            if (cueFramePos >= currentFramePos) {
+                if (cuesFromCurrentPosition.isEmpty()) {
+                    cuesFromCurrentPosition.append(cueFramePos);
+                } else if (cuesFromCurrentPosition.first() < cueFramePos) {
+                    cuesFromCurrentPosition.append(cueFramePos);
+                } else {
+                    cuesFromCurrentPosition.insert(0, cueFramePos);
+                }
+            }
+        }
+    }
+
+    //ToDo (Maldini) - Add the outro position to the CueList to count down until end of the track
+
+    //Since the cuesFromCurrentPosition is ordered, we only need to calculate the difference from the current position
+    //with the first element of the list, which would be the closest CUE point to the current play position
+    //ToDo (Maldini) - Get beat counters for every cue point to help with multi drop mixes
+    std::double_t beatsToNextCue = 0.0;
+    if (!cuesFromCurrentPosition.isEmpty()) {
+        mixxx::audio::FramePos closestCueFramePos =
+                cuesFromCurrentPosition.first();
+        pBeats->numBeatsInRange(
+                currentFramePos, closestCueFramePos);
+        beatsToNextCue = pBeats->numBeatsInRange(
+                        currentFramePos, closestCueFramePos);
+    } 
+
+    //ToDo (Maldini) - Count until outro after the last cue point
+    m_pBeatCountNextCue->forceSet(beatsToNextCue);
 }

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -44,12 +44,17 @@ void ClockControl::trackLoaded(TrackPointer pNewTrack) {
         m_pTrackCues = pNewTrack->getCuePoints();
     }
     trackBeatsUpdated(pBeats);
+    QObject::connect(pNewTrack.get(), &Track::cuesUpdatedWithCueList, this, &ClockControl::trackCuesUpdated);
 }
 
 void ClockControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     // Clear on-beat control
     m_pCOBeatActive->forceSet(0.0);
     m_pBeats = pBeats;
+}
+
+void ClockControl::trackCuesUpdated(QList<CuePointer> cuePointerList) {
+    m_pTrackCues = cuePointerList;
 }
 
 void ClockControl::updateIndicators(const double dRate,
@@ -233,8 +238,6 @@ void ClockControl::updateBeatCounter(mixxx::BeatsPointer pBeats,
             }
         }
     }
-
-    //ToDo (Maldini) - Add the outro position to the CueList to count down until end of the track
 
     //Since the cuesFromCurrentPosition is ordered, we only need to calculate the difference from the current position
     //with the first element of the list, which would be the closest CUE point to the current play position

--- a/src/engine/controls/clockcontrol.h
+++ b/src/engine/controls/clockcontrol.h
@@ -7,6 +7,7 @@
 #include "preferences/usersettings.h"
 #include "track/beats.h"
 #include "track/track_decl.h"
+#include "track/track.h"
 
 class ControlProxy;
 class ControlObject;
@@ -27,7 +28,15 @@ class ClockControl: public EngineControl {
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   private:
+    
+      //Updates the beat_count_next_cue CO with the number of beats until next cue
+    void updateBeatCounter(mixxx::BeatsPointer pBeats, mixxx::audio::FramePos currentFramePos);
+
     std::unique_ptr<ControlObject> m_pCOBeatActive;
+
+    //CO to communicate with Beat Counter widget
+    std::unique_ptr<ControlObject> m_pBeatCountNextCue;
+    QList<CuePointer> m_pTrackCues;
 
     // ControlObjects that come from LoopingControl
     std::unique_ptr<ControlProxy> m_pLoopEnabled;

--- a/src/engine/controls/clockcontrol.h
+++ b/src/engine/controls/clockcontrol.h
@@ -26,6 +26,7 @@ class ClockControl: public EngineControl {
 
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
+    void trackCuesUpdated(QList<CuePointer> cuePointerList);
 
   private:
     

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -323,7 +323,7 @@ class EngineBuffer : public EngineObject {
     double m_dSlipRate;
     // m_bSlipEnabledProcessing is only used by the engine processing thread.
     bool m_bSlipEnabledProcessing;
-
+    
     ControlObject* m_pTrackSamples;
     ControlObject* m_pTrackSampleRate;
 

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1220,7 +1220,7 @@ QWidget* LegacySkinParser::parseNumberRate(const QDomElement& node) {
 QWidget* LegacySkinParser::parseNumberPos(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     int channel = m_pContext->selectInt(node, "Channel");
-    WNumberPos* p = new WNumberPos(group, m_pParent, m_pPlayerManager->getDeck(channel));
+    WNumberPos* p = new WNumberPos(group, m_pParent);
     setupLabelWidget(node, p);
     return p;
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -917,6 +917,7 @@ void Track::setMainCuePosition(mixxx::audio::FramePos position) {
 
     markDirtyAndUnlock(&locked);
     emit cuesUpdated();
+    emit cuesUpdatedWithCueList(m_cuePoints);
 }
 
 void Track::shiftCuePositionsMillis(double milliseconds) {
@@ -976,6 +977,7 @@ CuePointer Track::createAndAddCue(
     m_cuePoints.push_back(pCue);
     markDirtyAndUnlock(&locked);
     emit cuesUpdated();
+    emit cuesUpdatedWithCueList(m_cuePoints);
     return pCue;
 }
 
@@ -1017,6 +1019,7 @@ void Track::removeCue(const CuePointer& pCue) {
     }
     markDirtyAndUnlock(&locked);
     emit cuesUpdated();
+    emit cuesUpdatedWithCueList(m_cuePoints);
 }
 
 void Track::removeCuesOfType(mixxx::CueType type) {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -468,6 +468,8 @@ class Track : public QObject {
     void cuesUpdated();
     void analyzed();
 
+    void cuesUpdatedWithCueList(QList<CuePointer> cuePointerList);
+
     void changed(TrackId trackId);
     void dirty(TrackId trackId);
     void clean(TrackId trackId);

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -104,9 +104,13 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
         if (m_pDeck) {
             TrackPointer m_pTrack = m_pDeck->getLoadedTrack();
             if (m_pTrack) {
-                mixxx::audio::FramePos currentFramePos = m_pDeck->getEngineDeck()->getEngineBuffer()->getExactPlayPos();
+                mixxx::audio::FramePos currentFramePos = 
+                    m_pDeck->getEngineDeck()
+                        ->getEngineBuffer()
+                        ->getExactPlayPos();
                 QList<CuePointer> trackCues = m_pTrack->getCuePoints();
-                QList<mixxx::audio::FramePos> cuesFromCurrentPosition = QList<mixxx::audio::FramePos>();
+                QList<mixxx::audio::FramePos> cuesFromCurrentPosition = 
+                    QList<mixxx::audio::FramePos>();
 
                 //Iterate through current Track cues and create a list with the FramePos of the ones
                 // that are after the current play position. We add them ordered in the new list
@@ -133,13 +137,17 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
                             cuesFromCurrentPosition.first();
                     m_pTrack->getBeats()->numBeatsInRange(
                             currentFramePos, closestCueFramePos);
-                    cuesText = std::to_string(m_pTrack->getBeats()->numBeatsInRange(currentFramePos, closestCueFramePos));
+                    cuesText = std::to_string(
+                        m_pTrack->getBeats()->numBeatsInRange(
+                            currentFramePos, closestCueFramePos));
 
                 } else {
-                    setText(QString::fromStdString("No cues left | -") + timeFormat(dTimeRemaining, precision));
+                    setText(QString::fromStdString("No cues left | -") + 
+                        timeFormat(dTimeRemaining, precision));
                 }
 
-                setText(QString::fromStdString(cuesText + " beats | " + "-") + timeFormat(dTimeRemaining, precision));
+                setText(QString::fromStdString(cuesText + " beats | " + "-") + 
+                    timeFormat(dTimeRemaining, precision));
 
             } else {
                 //Fallback to remaining time display

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -3,18 +3,16 @@
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "engine/enginebuffer.h"
-#include "mixer/deck.h"
 #include "moc_wnumberpos.cpp"
 #include "track/track.h"
 #include "util/duration.h"
 #include "util/math.h"
 
-WNumberPos::WNumberPos(const QString& group, QWidget* parent, Deck* deck)
+WNumberPos::WNumberPos(const QString& group, QWidget* parent)
         : WNumber(parent),
           m_displayFormat(TrackTime::DisplayFormat::TRADITIONAL),
           m_dOldTimeElapsed(0.0) {
-    m_pDeck = deck;
-
+    
     m_pTimeElapsed = new ControlProxy(group, "time_elapsed", this, ControlFlag::NoAssertIfMissing);
     m_pTimeElapsed->connectValueChanged(this, &WNumberPos::slotSetTimeElapsed);
     m_pTimeRemaining = new ControlProxy(
@@ -33,6 +31,12 @@ WNumberPos::WNumberPos(const QString& group, QWidget* parent, Deck* deck)
     m_pTimeFormat->connectValueChanged(
             this, &WNumberPos::slotSetTimeFormat);
     slotSetTimeFormat(m_pTimeFormat->get());
+
+    m_pBeatCountNextCue = new ControlProxy(
+        group, "beat_count_next_cue", this);
+    m_pBeatCountNextCue->connectValueChanged(
+            this, &WNumberPos::slotSetBeatCounter);
+    slotSetBeatCounter(m_pBeatCountNextCue->get());
 }
 
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
@@ -101,64 +105,17 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
                     % QLatin1String("  -") % timeFormat(dTimeRemaining, precision));
         }
     } else if (m_displayMode == TrackTime::DisplayMode::BEATS_UNTIL_NEXT_CUE_AND_REMAINING) {
-        if (m_pDeck) {
-            TrackPointer m_pTrack = m_pDeck->getLoadedTrack();
-            if (m_pTrack) {
-                mixxx::audio::FramePos currentFramePos = 
-                    m_pDeck->getEngineDeck()
-                        ->getEngineBuffer()
-                        ->getExactPlayPos();
-                QList<CuePointer> trackCues = m_pTrack->getCuePoints();
-                QList<mixxx::audio::FramePos> cuesFromCurrentPosition = 
-                    QList<mixxx::audio::FramePos>();
 
-                //Iterate through current Track cues and create a list with the FramePos of the ones
-                // that are after the current play position. We add them ordered in the new list
-                for (int i = 0; i < trackCues.count(); ++i) {
-                    CuePointer cue = trackCues[i];
-                    mixxx::audio::FramePos cueFramePos = cue->getPosition();
-                    if (cueFramePos.isValid() && cueFramePos >= currentFramePos) {
-                        if (cuesFromCurrentPosition.isEmpty()) {
-                            cuesFromCurrentPosition.append(cueFramePos);
-                        } else if (cuesFromCurrentPosition.first() < cueFramePos) {
-                            cuesFromCurrentPosition.append(cueFramePos);
-                        } else {
-                            cuesFromCurrentPosition.insert(0, cueFramePos);
-                        }
-                    }
-                }
+        //ToDo (Maldini) - Count until outro after the last cue point
+        setText(QString::fromStdString(std::to_string((int) pBeatsToNextCue) + " beats | " + "-") + 
+            timeFormat(dTimeRemaining, precision));
 
-                //Since the cuesFromCurrentPosition is ordered, we only need to calculate the difference from the current position
-                //with the first element of the list, which would be the closest CUE point to the current play position
-                //ToDo (Maldini) - Get beat counters for every cue point to help with multi drop mixes
-                std::string cuesText = "";
-                if (!cuesFromCurrentPosition.isEmpty()) {
-                    mixxx::audio::FramePos closestCueFramePos =
-                            cuesFromCurrentPosition.first();
-                    m_pTrack->getBeats()->numBeatsInRange(
-                            currentFramePos, closestCueFramePos);
-                    cuesText = std::to_string(
-                        m_pTrack->getBeats()->numBeatsInRange(
-                            currentFramePos, closestCueFramePos));
-
-                } else {
-                    setText(QString::fromStdString("No cues left | -") + 
-                        timeFormat(dTimeRemaining, precision));
-                }
-
-                setText(QString::fromStdString(cuesText + " beats | " + "-") + 
-                    timeFormat(dTimeRemaining, precision));
-
-            } else {
+            /*
                 //Fallback to remaining time display
                 setText(QLatin1String("-") %
                         timeFormat(dTimeRemaining, precision));
-            }
-        } else {
-            //Fallback to remaining time display
-            setText(QLatin1String("-") % timeFormat(dTimeRemaining, precision));
-        }
-    }
+            */
+    } 
     m_dOldTimeElapsed = dTimeElapsed;
 }
 
@@ -190,4 +147,12 @@ void WNumberPos::slotSetTimeFormat(double v) {
     m_displayFormat = static_cast<TrackTime::DisplayFormat>(static_cast<int>(v));
 
     slotSetTimeElapsed(m_dOldTimeElapsed);
+}
+
+void WNumberPos::slotSetBeatCounter(double beatsToNextCue) {
+    /* if (m_displayMode == TrackTime::DisplayMode::BEATS_UNTIL_NEXT_CUE_AND_REMAINING) {
+        //ToDo (Maldini) - Count until outro after the last cue point
+        setText(QString::fromStdString(std::to_string(beatsToNextCue) + " beats"));
+    }*/
+    pBeatsToNextCue = beatsToNextCue;
 }

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -12,7 +12,7 @@ class WNumberPos : public WNumber {
     Q_OBJECT
 
   public:
-    explicit WNumberPos(const QString& group, QWidget* parent = nullptr, Deck* deck = nullptr);
+    explicit WNumberPos(const QString& group, QWidget* parent = nullptr);
 
   protected:
     void mousePressEvent(QMouseEvent* pEvent) override;
@@ -23,6 +23,7 @@ class WNumberPos : public WNumber {
     void slotTimeRemainingUpdated(double);
     void slotSetDisplayMode(double);
     void slotSetTimeFormat(double);
+    void slotSetBeatCounter(double);
 
   private:
 
@@ -35,7 +36,6 @@ class WNumberPos : public WNumber {
     ControlProxy* m_pShowTrackTimeRemaining;
     ControlProxy* m_pTimeFormat;
 
-    //We will use this to look for the track cues and update the
-    //BeatsUntilNextCueAndRemaining display mode
-    Deck* m_pDeck;
+    ControlProxy* m_pBeatCountNextCue;
+    double pBeatsToNextCue;
 };


### PR DESCRIPTION
Updated the implementation using a new ControlObject (beat_count_next_cue) implemented in src/engine/controls/clockcontrol